### PR TITLE
Staying closer to Unleash java API

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,16 @@
 [![Clojars Project](https://img.shields.io/clojars/v/unleash-client-clojure.svg)](https://clojars.org/unleash-client-clojure)
 
 A Clojure library wrapping [unleash java client](https://github.com/Unleash/unleash-client-java)
+
 ## Usage
 
 ### Getting feature toggles
+
 ```clojure
-(require '[unleash-client-clojure.unleash :as u])
+(require '[unleash-client-clojure.unleash :as u]
+         '[unleash-client-clojure.builder :as b])
 ;; a simple client
-(def unleash (u/build "app-name" "instance-id" "http://unleash.herokuapp.com/api/"))
+(def unleash (u/build (b/app-name "app-name") (b/unleash-api "http://unleash.herokuapp.com/api/")))
 ;; simple toggle
 (u/enabled? unleash "Bit")
 ;; toggle with context
@@ -22,6 +25,7 @@ A Clojure library wrapping [unleash java client](https://github.com/Unleash/unle
 ```
 
 ### Variant support
+
 ```clojure
 (require '[unleash-client-clojure.variant :as v])
 (u/get-variant unleash "DemoVariantWithPayload")
@@ -33,16 +37,20 @@ A Clojure library wrapping [unleash java client](https://github.com/Unleash/unle
 ```
 
 ### Advanced client config
+
 ```clojure
 ;; the builder namespace supports passing builder confgurations as functions
 (require '[unleash-client-clojure.builder :as b])
-(def unleash (u/build "app-name" "instance-id" "http://unleash.herokuapp.com/api/" 
-             (b/environment "staging")
-             (b/fetch-toggles-interval 1)))
+(def unleash (u/build
+               (b/app-name "app-name")
+               (b/unleash-api "http://unleash.herokuapp.com/api/")
+               (b/environment "staging")
+               (b/fetch-toggles-interval 1)))
 ;; see the builder namespace for more available options
 ```
 
 ### Subscriber support
+
 ```clojure
 ;; one a subscriber can be pased to the client builder by passing
 (b/subscriber my-subscriber)
@@ -54,12 +62,13 @@ A Clojure library wrapping [unleash java client](https://github.com/Unleash/unle
 ;; any missing key defaults to no-op
 ;; this is a very noisy example:
 (def unleash
-    (u/build "app-name"
-             "instance-id" 
-             "http://unleash.herokuapp.com/api/"
-             (b/subscriber
-                (s/build {:on-event println})))
+  (u/build
+    (b/app-name "app-name")
+    (b/unleash-api "http://unleash.herokuapp.com/api/")
+    (b/subscriber
+      (s/build {:on-event println})))
 ```
 
 #### TODO:
+
 - [ ] Integration testing

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject unleash-client-clojure "0.1.1"
+(defproject unleash-client-clojure "0.2.0"
   :description "A Clojure library wrapping https://github.com/Unleash/unleash-client-java"
   :url "https://github.com/AppsFlyer/unleash-client-clojure"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject unleash-client-clojure "0.2.0"
+(defproject unleash-client-clojure "0.2.0-SNAPSHOT"
   :description "A Clojure library wrapping https://github.com/Unleash/unleash-client-java"
   :url "https://github.com/AppsFlyer/unleash-client-clojure"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/unleash_client_clojure/builder.clj
+++ b/src/unleash_client_clojure/builder.clj
@@ -3,21 +3,28 @@
            [no.finn.unleash.util UnleashConfig UnleashConfig$Builder UnleashScheduledExecutor]
            [no.finn.unleash.event UnleashSubscriber]))
 
-(defn build ^UnleashConfig 
-  [app-name ^String instance-id ^String api & fs]
-  (let [bldr
-        (-> (UnleashConfig$Builder.)
-            (.appName app-name)
-            (.instanceId instance-id)
-            (.unleashAPI api))]
+(defn build ^UnleashConfig [& fs]
+  (let [bldr (UnleashConfig$Builder.)]
     (.build ^UnleashConfig$Builder
             (reduce
               (fn
-                ([] bldr) 
+                ([] bldr)
                 ([bldr f]
                  (f bldr)))
               bldr
               fs))))
+
+(defn app-name [^String name]
+  (fn [^UnleashConfig$Builder bldr]
+    (.appName bldr name)))
+
+(defn instance-id [^String id]
+  (fn [^UnleashConfig$Builder bldr]
+    (.instanceId bldr id)))
+
+(defn unleash-api [^String api]
+  (fn [^UnleashConfig$Builder bldr]
+    (.unleashAPI bldr api)))
 
 (defn custom-http-header [header-name header-value]
   (fn [^UnleashConfig$Builder bldr]

--- a/src/unleash_client_clojure/unleash.clj
+++ b/src/unleash_client_clojure/unleash.clj
@@ -53,11 +53,11 @@
     (vec (.getFeatureToggleNames this))))
 
 (defn build
-  [app-name ^String instance-id ^String api & fs]
-  (DefaultUnleash. (apply builder/build app-name instance-id api fs)
+  [& fs]
+  (DefaultUnleash. (apply builder/build fs)
                    (into-array Strategy [])))
 
 (defn build-with-custom-strategies
-  [app-name ^String instance-id ^String api strategies & fs]
-  (DefaultUnleash. (apply builder/build app-name instance-id api fs)
+  [strategies & fs]
+  (DefaultUnleash. (apply builder/build fs)
                    (into-array Strategy strategies)))

--- a/test/unleash_client_clojure/builder_test.clj
+++ b/test/unleash_client_clojure/builder_test.clj
@@ -9,14 +9,17 @@
 
 (deftest builder
   (testing "building unleash sets correct config"
-    (let [app-name "app" 
-          instance-id "some-instance" 
+    (let [app-name "app"
+          instance-id "some-instance"
           api "http://127.0.0.1"
-          backup-path (s/join File/separatorChar 
+          backup-path (s/join File/separatorChar
                               [(System/getProperty "java.io.tmpdir") (str (rand-int 100) ".json")])
           context (c/build (c/app-name "some-app"))
           subscriber (subscriber/build {})
-          config (b/build app-name instance-id api
+          config (b/build
+                   (b/app-name app-name)
+                   (b/instance-id instance-id)
+                   (b/unleash-api api)
                    (b/custom-http-header "header-name" "header-value")
                    (b/send-metrics-interval 42)
                    (b/fetch-toggles-interval 43)
@@ -26,12 +29,12 @@
                    (b/environment "staging")
                    (b/custom-http-header-provider
                      (reify CustomHttpHeadersProvider
-                        (getCustomHeaders [_] {"foo" "bar"})))
+                       (getCustomHeaders [_] {"foo" "bar"})))
                    (b/unleash-context-provider
                      (reify UnleashContextProvider
-                        (getContext [_] context)))
+                       (getContext [_] context)))
                    (b/subscriber subscriber))]
-                   
+
       (is (= {"header-name" "header-value"}
              (.getCustomHttpHeaders config)))
       (is (= 42


### PR DESCRIPTION
We do not want to make users define app-name, instance-id and api while creating new client or new config. Not 3 of them needed for client creation. we want it as in java API.