### PR TITLE
Documentation overhaul 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ pom.xml.asc
 .lsp
 .settings
 .project
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
         - stage: build
           script: lein javac
         - stage: test
-          script: lein do clean, javac, test
+          script: lein do clean, test
 after_success:
     - bash -ex test/coveralls.sh
 notifications:

--- a/doc/intro.md
+++ b/doc/intro.md
@@ -1,3 +1,0 @@
-# Introduction to unleash-client-clojure
-
-TODO: write [great documentation](http://jacobian.org/writing/what-to-write/)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject unleash-client-clojure "0.2.0"
+(defproject unleash-client-clojure "0.3.0"
   :description "A Clojure library wrapping https://github.com/Unleash/unleash-client-java"
   :url "https://github.com/AppsFlyer/unleash-client-clojure"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,14 +1,14 @@
-(defproject unleash-client-clojure "0.3.0"
+(defproject unleash-client-clojure "0.2.1"
   :description "A Clojure library wrapping https://github.com/Unleash/unleash-client-java"
   :url "https://github.com/AppsFlyer/unleash-client-clojure"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
-            :url "https://www.eclipse.org/legal/epl-2.0/"}
+            :url  "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[no.finn.unleash/unleash-client-java "3.3.3"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.1"]
                                   [clj-kondo "RELEASE"]
                                   [org.apache.logging.log4j/log4j-core "2.11.2"]]
-                    :aliases      {"clj-kondo" ["run" "-m" "clj-kondo.main"]
-                                   "lint"      ["run" "-m" "clj-kondo.main" "--lint" "src" "test"]}
-                    :plugins     [[lein-ancient "0.6.15"]
+                   :aliases      {"clj-kondo" ["run" "-m" "clj-kondo.main"]
+                                  "lint"      ["run" "-m" "clj-kondo.main" "--lint" "src" "test"]}
+                   :plugins      [[lein-ancient "0.6.15"]
                                   [lein-cloverage "1.2.0"]]
-                    :global-vars {*warn-on-reflection* true}}})
+                   :global-vars  {*warn-on-reflection* true}}})

--- a/src/unleash_client_clojure/builder.clj
+++ b/src/unleash_client_clojure/builder.clj
@@ -5,46 +5,47 @@
            [no.finn.unleash.event UnleashSubscriber]))
 
 (defn build
-  "Expects a sequence of functions, each of which expects an UnleashConfig$Builder instance.
+  "Expects to be applied with a variadic number of arguments, each of which is a function that expects an
+  UnleashConfig$Builder instance.
   Returns an instance of UnleashConfig that had all of its parameters set by said functions.
 
   Using this building pattern allows users to manipulate the builder instance in ways that aren't
   implemented in this library by passing a function that expects an UnleashConfig$Builder.
 
   Example:
-  (build [(app-name \"test-app\")
-          (unleash-api \"http://example.unleash.com/api\")])"
+  (build (app-name \"test-app\")
+         (unleash-api \"http://example.unleash.com/api\"))"
   ^UnleashConfig [& builder-param-setters]
-  (let [bldr (UnleashConfig$Builder.)]
+  (let [builder (UnleashConfig$Builder.)]
     (.build ^UnleashConfig$Builder
             (reduce
               (fn
-                ([] bldr)
-                ([bldr set-builder-param]
-                 (set-builder-param bldr)))
-              bldr
+                ([] builder)
+                ([builder set-builder-param]
+                 (set-builder-param builder)))
+              builder
               builder-param-setters))))
 
 (defn app-name
-  "Expects an application's name.
+  "Expects an application name.
   Returns a function that expects an UnleashConfig$Builder, and sets the appName property of the builder."
   [^String name]
-  (fn [^UnleashConfig$Builder bldr]
-    (.appName bldr name)))
+  (fn [^UnleashConfig$Builder builder]
+    (.appName builder name)))
 
 (defn instance-id
-  "Expects an instance's ID.
+  "Expects an instance ID.
   Returns a function that expects an UnleashConfig$Builder, and sets the instanceId property of the builder."
   [^String id]
-  (fn [^UnleashConfig$Builder bldr]
-    (.instanceId bldr id)))
+  (fn [^UnleashConfig$Builder builder]
+    (.instanceId builder id)))
 
 (defn unleash-api
   "Expects a URL for an Unleash server.
   Returns a function that expects an UnleashConfig$Builder, and sets the unleashAPI property of the builder."
   [^String api]
-  (fn [^UnleashConfig$Builder bldr]
-    (.unleashAPI bldr api)))
+  (fn [^UnleashConfig$Builder builder]
+    (.unleashAPI builder api)))
 
 (defn custom-http-header
   "Expects an HTTP header name and value.
@@ -59,53 +60,53 @@
           (custom-http-header \"X-AF-HEADER-2\" \"b\")
           (custom-http-header \"X-AF-HEADER-3\" \"c\")])"
   [header-name header-value]
-  (fn [^UnleashConfig$Builder bldr]
-    (.customHttpHeader bldr header-name header-value)))
+  (fn [^UnleashConfig$Builder builder]
+    (.customHttpHeader builder header-name header-value)))
 
 (defn send-metrics-interval
   "Expects a long that marks the interval (in seconds) of sending metrics.
   Returns a function that expects an UnleashConfig$Builder, and sets the sendMetricsInterval property of the builder."
   [^Long interval-seconds]
-  (fn [^UnleashConfig$Builder bldr]
-    (.sendMetricsInterval bldr interval-seconds)))
+  (fn [^UnleashConfig$Builder builder]
+    (.sendMetricsInterval builder interval-seconds)))
 
 (defn fetch-toggles-interval
   "Expects a long that marks the interval (in seconds) of fetching toggles' states from the Unleash server.
   Returns a function that expects an UnleashConfig$Builder, and sets the fetchTogglesInterval property of the builder."
   [^Long interval-seconds]
-  (fn [^UnleashConfig$Builder bldr]
-    (.fetchTogglesInterval bldr interval-seconds)))
+  (fn [^UnleashConfig$Builder builder]
+    (.fetchTogglesInterval builder interval-seconds)))
 
 (defn synchronous-fetch-on-initialisation
   "Expects a boolean that controls if toggles are fetched synchronously when the Unleash client is initialised.
   Returns a function that expects an UnleashConfig$Builder, and sets the synchronousFetchOnInitialisation property of
   the builder."
   [enable?]
-  (fn [^UnleashConfig$Builder bldr]
-    (.synchronousFetchOnInitialisation bldr enable?)))
+  (fn [^UnleashConfig$Builder builder]
+    (.synchronousFetchOnInitialisation builder enable?)))
 
 (defn enable-proxy-authentication-by-jvm-properties
   "Expects a boolean that controls if authentication against an HTTP proxy would use the JVM settings http.proxyUser and
   http.proxyPassword.
   Returns a function that expects an UnleashConfig$Builder, and sets the isProxyAuthenticationByJvmProperties property of the builder."
   []
-  (fn [^UnleashConfig$Builder bldr]
-    (.enableProxyAuthenticationByJvmProperties bldr)))
+  (fn [^UnleashConfig$Builder builder]
+    (.enableProxyAuthenticationByJvmProperties builder)))
 
 (defn backup-file
   "Expects a backup file path, into which the Unleash client would backup its state to be used when the Unleash server
   is unavailable. By defeault this would be unleash-repo.json in the directory set by the JVM property java.io.tmpdir.
   Returns a function that expects an UnleashConfig$Builder, and sets the backupFile property of the builder."
   [^String backup-file]
-  (fn [^UnleashConfig$Builder bldr]
-    (.backupFile bldr backup-file)))
+  (fn [^UnleashConfig$Builder builder]
+    (.backupFile builder backup-file)))
 
 (defn environment
-  "Expects an application's environment.
+  "Expects an application environment.
   Returns a function that expects an UnleashConfig$Builder, and sets the environment property of the builder."
   [^String environment]
-  (fn [^UnleashConfig$Builder bldr]
-    (.environment bldr environment)))
+  (fn [^UnleashConfig$Builder builder]
+    (.environment builder environment)))
 
 (defn custom-http-header-provider
   "Expects an instance of CustomHttpHeadersProvider, which adds headers to outgoing HTTP requests that are sent to the
@@ -113,28 +114,29 @@
   Returns a function that expects an UnleashConfig$Builder, and sets the custom-http-headers-provider property of the
   builder."
   [^CustomHttpHeadersProvider provider]
-  (fn [^UnleashConfig$Builder bldr]
-    (.customHttpHeadersProvider bldr provider)))
+  (fn [^UnleashConfig$Builder builder]
+    (.customHttpHeadersProvider builder provider)))
+
 
 (defn unleash-context-provider
   "Expects an instance of UnleashContextProvider, which would provide the context for calls of enabled? instead of
   having it provided as an arguments in the call site.
   Returns a function that expects an UnleashConfig$Builder, and sets the contextProvider property of the builder."
   [^UnleashContextProvider provider]
-  (fn [^UnleashConfig$Builder bldr]
-    (.unleashContextProvider bldr provider)))
+  (fn [^UnleashConfig$Builder builder]
+    (.unleashContextProvider builder provider)))
 
 (defn scheduled-executor
   "Expects an instance of UnleashScheduledExecutor, which would be used to periodically send usage metrics. The interval
   of sending those metrics can be set with 'send-metrics-interval'.
   Returns a function that expects an UnleashConfig$Builder, and sets the scheduledExecutor property of the builder."
   [^UnleashScheduledExecutor executor]
-  (fn [^UnleashConfig$Builder bldr]
-    (.scheduledExecutor bldr executor)))
+  (fn [^UnleashConfig$Builder builder]
+    (.scheduledExecutor builder executor)))
 
 (defn subscriber
   "Expects an instance of UnleashSubscriber, which would be notified when the Unleash client's internal state changes.
   Returns a function that expects an UnleashConfig$Builder, and sets the subscriber property of the builder."
   [^UnleashSubscriber subscriber]
-  (fn [^UnleashConfig$Builder bldr]
-    (.subscriber bldr subscriber)))
+  (fn [^UnleashConfig$Builder builder]
+    (.subscriber builder subscriber)))

--- a/src/unleash_client_clojure/builder.clj
+++ b/src/unleash_client_clojure/builder.clj
@@ -1,71 +1,140 @@
 (ns unleash-client-clojure.builder
+  "Create and configure builders that build instances of UnleashConfig."
   (:import [no.finn.unleash CustomHttpHeadersProvider UnleashContextProvider]
            [no.finn.unleash.util UnleashConfig UnleashConfig$Builder UnleashScheduledExecutor]
            [no.finn.unleash.event UnleashSubscriber]))
 
-(defn build ^UnleashConfig [& fs]
+(defn build
+  "Expects a sequence of functions, each of which expects an UnleashConfig$Builder instance.
+  Returns an instance of UnleashConfig that had all of its parameters set by said functions.
+
+  Using this building pattern allows users to manipulate the builder instance in ways that aren't
+  implemented in this library by passing a function that expects an UnleashConfig$Builder.
+
+  Example:
+  (build [(app-name \"test-app\")
+          (unleash-api \"http://example.unleash.com/api\")])"
+  ^UnleashConfig [& builder-param-setters]
   (let [bldr (UnleashConfig$Builder.)]
     (.build ^UnleashConfig$Builder
             (reduce
               (fn
                 ([] bldr)
-                ([bldr f]
-                 (f bldr)))
+                ([bldr set-builder-param]
+                 (set-builder-param bldr)))
               bldr
-              fs))))
+              builder-param-setters))))
 
-(defn app-name [^String name]
+(defn app-name
+  "Expects an application's name.
+  Returns a function that expects an UnleashConfig$Builder, and sets the appName property of the builder."
+  [^String name]
   (fn [^UnleashConfig$Builder bldr]
     (.appName bldr name)))
 
-(defn instance-id [^String id]
+(defn instance-id
+  "Expects an instance's ID.
+  Returns a function that expects an UnleashConfig$Builder, and sets the instanceId property of the builder."
+  [^String id]
   (fn [^UnleashConfig$Builder bldr]
     (.instanceId bldr id)))
 
-(defn unleash-api [^String api]
+(defn unleash-api
+  "Expects a URL for an Unleash server.
+  Returns a function that expects an UnleashConfig$Builder, and sets the unleashAPI property of the builder."
+  [^String api]
   (fn [^UnleashConfig$Builder bldr]
     (.unleashAPI bldr api)))
 
-(defn custom-http-header [header-name header-value]
+(defn custom-http-header
+  "Expects an HTTP header name and value.
+  Returns a function that expects an UnleashConfig$Builder, and adds the relevant HTTP header name and value to the headers used by the builder.
+  These headers would be added to outgoing HTTP requests sent by the Unleash client to the Unleash server.
+
+  Can be used multiple times to set multiple headers.
+
+  Example:
+  (build [(unleash-api \"http://example.unleash.com/api\")
+          (custom-http-header \"X-AF-HEADER-1\" \"a\")
+          (custom-http-header \"X-AF-HEADER-2\" \"b\")
+          (custom-http-header \"X-AF-HEADER-3\" \"c\")])"
+  [header-name header-value]
   (fn [^UnleashConfig$Builder bldr]
     (.customHttpHeader bldr header-name header-value)))
 
-(defn send-metrics-interval [^Long interval-seconds]
+(defn send-metrics-interval
+  "Expects a long that marks the interval (in seconds) of sending metrics.
+  Returns a function that expects an UnleashConfig$Builder, and sets the sendMetricsInterval property of the builder."
+  [^Long interval-seconds]
   (fn [^UnleashConfig$Builder bldr]
     (.sendMetricsInterval bldr interval-seconds)))
 
-(defn fetch-toggles-interval [^Long interval-seconds]
+(defn fetch-toggles-interval
+  "Expects a long that marks the interval (in seconds) of fetching toggles' states from the Unleash server.
+  Returns a function that expects an UnleashConfig$Builder, and sets the fetchTogglesInterval property of the builder."
+  [^Long interval-seconds]
   (fn [^UnleashConfig$Builder bldr]
     (.fetchTogglesInterval bldr interval-seconds)))
 
-(defn synchronous-fetch-on-initialisation [enable?]
+(defn synchronous-fetch-on-initialisation
+  "Expects a boolean that controls if toggles are fetched synchronously when the Unleash client is initialised.
+  Returns a function that expects an UnleashConfig$Builder, and sets the synchronousFetchOnInitialisation property of
+  the builder."
+  [enable?]
   (fn [^UnleashConfig$Builder bldr]
     (.synchronousFetchOnInitialisation bldr enable?)))
 
-(defn enable-proxy-authentication-by-jvm-properties []
+(defn enable-proxy-authentication-by-jvm-properties
+  "Expects a boolean that controls if authentication against an HTTP proxy would use the JVM settings http.proxyUser and
+  http.proxyPassword.
+  Returns a function that expects an UnleashConfig$Builder, and sets the isProxyAuthenticationByJvmProperties property of the builder."
+  []
   (fn [^UnleashConfig$Builder bldr]
     (.enableProxyAuthenticationByJvmProperties bldr)))
 
-(defn backup-file [^String backup-file]
+(defn backup-file
+  "Expects a backup file path, into which the Unleash client would backup its state to be used when the Unleash server
+  is unavailable. By defeault this would be unleash-repo.json in the directory set by the JVM property java.io.tmpdir.
+  Returns a function that expects an UnleashConfig$Builder, and sets the backupFile property of the builder."
+  [^String backup-file]
   (fn [^UnleashConfig$Builder bldr]
     (.backupFile bldr backup-file)))
 
-(defn environment [^String environment]
+(defn environment
+  "Expects an application's environment.
+  Returns a function that expects an UnleashConfig$Builder, and sets the environment property of the builder."
+  [^String environment]
   (fn [^UnleashConfig$Builder bldr]
     (.environment bldr environment)))
 
-(defn custom-http-header-provider [^CustomHttpHeadersProvider provider]
+(defn custom-http-header-provider
+  "Expects an instance of CustomHttpHeadersProvider, which adds headers to outgoing HTTP requests that are sent to the
+  Unleash server, based on the contents of the request itself.
+  Returns a function that expects an UnleashConfig$Builder, and sets the custom-http-headers-provider property of the
+  builder."
+  [^CustomHttpHeadersProvider provider]
   (fn [^UnleashConfig$Builder bldr]
     (.customHttpHeadersProvider bldr provider)))
 
-(defn unleash-context-provider [^UnleashContextProvider provider]
+(defn unleash-context-provider
+  "Expects an instance of UnleashContextProvider, which would provide the context for calls of enabled? instead of
+  having it provided as an arguments in the call site.
+  Returns a function that expects an UnleashConfig$Builder, and sets the contextProvider property of the builder."
+  [^UnleashContextProvider provider]
   (fn [^UnleashConfig$Builder bldr]
     (.unleashContextProvider bldr provider)))
 
-(defn scheduled-executor [^UnleashScheduledExecutor executor]
+(defn scheduled-executor
+  "Expects an instance of UnleashScheduledExecutor, which would be used to periodically send usage metrics. The interval
+  of sending those metrics can be set with 'send-metrics-interval'.
+  Returns a function that expects an UnleashConfig$Builder, and sets the scheduledExecutor property of the builder."
+  [^UnleashScheduledExecutor executor]
   (fn [^UnleashConfig$Builder bldr]
     (.scheduledExecutor bldr executor)))
 
-(defn subscriber [^UnleashSubscriber subscriber]
+(defn subscriber
+  "Expects an instance of UnleashSubscriber, which would be notified when the Unleash client's internal state changes.
+  Returns a function that expects an UnleashConfig$Builder, and sets the subscriber property of the builder."
+  [^UnleashSubscriber subscriber]
   (fn [^UnleashConfig$Builder bldr]
     (.subscriber bldr subscriber)))

--- a/src/unleash_client_clojure/context.clj
+++ b/src/unleash_client_clojure/context.clj
@@ -1,60 +1,112 @@
 (ns unleash-client-clojure.context
+  "Create and configure builders that build instances of UnleashContext."
   (:import [no.finn.unleash UnleashContext UnleashContext$Builder]))
 
-(defn build ^UnleashContext
-  [& fs]
-  (let [bldr (UnleashContext$Builder.)]
+(defn build
+  "Expects to be applied with a variadic number of arguments, each of which is a function that expects an
+  UnleashContext$Builder instance.
+  Returns an instance of UnleashContext that had all of its parameters set by said functions.
+
+  Using this building pattern allows users to manipulate the builder instance in ways that aren't
+  implemented in this library by passing a function that expects an UnleashContext$Builder.
+
+  Example:
+  (build (app-name \"test-app\")
+         (environment \"STG\"))
+
+  The UnleashContext instance can be attached to an Unleash client via
+  unleash-client-clojure.builder/unleash-context-provider."
+  ^UnleashContext
+  [& builder-param-setters]
+  (let [builder (UnleashContext$Builder.)]
     (.build ^UnleashContext$Builder
             (reduce
               (fn
-                ([] bldr)
-                ([bldr f]
-                 (f bldr)))
-              bldr
-              fs))))
+                ([] builder)
+                ([builder set-builder-param]
+                 (set-builder-param builder)))
+              builder
+              builder-param-setters))))
 
-(defn get-app-name [^UnleashContext ctx]
+(defn get-app-name
+  "Returns the app's name from the context."
+  [^UnleashContext ctx]
   (.get (.getAppName ctx)))
 
-(defn get-environment [^UnleashContext ctx]
+(defn get-environment
+  "Returns the environment from the context."
+  [^UnleashContext ctx]
   (.get (.getEnvironment ctx)))
 
-(defn get-user-id [^UnleashContext ctx]
+(defn get-user-id
+  "Returns the user ID from the context."
+  [^UnleashContext ctx]
   (.get (.getUserId ctx)))
 
-(defn get-session-id [^UnleashContext ctx]
+(defn get-session-id
+  "Returns the session ID from the context."
+  [^UnleashContext ctx]
   (.get (.getSessionId ctx)))
 
-(defn get-remote-address [^UnleashContext ctx]
+(defn get-remote-address
+  "Returns the remote address from the context."
+  [^UnleashContext ctx]
   (.get (.getRemoteAddress ctx)))
 
-(defn get-property [^UnleashContext ctx ^String property-name]
+(defn get-property
+  "Returns a context property"
+  [^UnleashContext ctx ^String property-name]
   (.get (.getProperties ctx) property-name))
 
-(defn get-by-name [^UnleashContext ctx ^String contextName]
+(defn get-by-name
+  "Returns a context property, explicitly looking for:
+  - environment
+  - appName
+  - userId
+  - sessionId
+  - remoteAddress
+  Otherwise, behaves as 'get-property'."
+  [^UnleashContext ctx ^String contextName]
   (.get (.getByName ctx contextName)))
 
-(defn app-name [^String app-name]
-  (fn [^UnleashContext$Builder bldr]
-    (.appName bldr app-name)))
+(defn app-name
+  "Expects an application's name.
+  Returns a function that expects an UnleashContext$Builder, and sets the appName property of the builder."
+  [^String app-name]
+  (fn [^UnleashContext$Builder builder]
+    (.appName builder app-name)))
 
-(defn environment [^String environment]
-  (fn [^UnleashContext$Builder bldr]
-    (.environment bldr environment)))
+(defn environment
+  "Expects an application environment.
+  Returns a function that expects an UnleashContext$Builder, and sets the environment property of the builder."
+  [^String environment]
+  (fn [^UnleashContext$Builder builder]
+    (.environment builder environment)))
 
-(defn user-id [^String id]
-  (fn [^UnleashContext$Builder bldr]
-    (.userId bldr id)))
+(defn user-id
+  "Expects a user ID.
+  Returns a function that expects an UnleashContext$Builder, and sets the userId property of the builder."
+  [^String id]
+  (fn [^UnleashContext$Builder builder]
+    (.userId builder id)))
 
-(defn session-id [^String id]
-  (fn [^UnleashContext$Builder bldr]
-    (.sessionId bldr id)))
+(defn session-id
+  "Expects a session ID.
+  Returns a function that expects an UnleashContext$Builder, and sets the sessionId property of the builder."
+  [^String id]
+  (fn [^UnleashContext$Builder builder]
+    (.sessionId builder id)))
 
-(defn remote-address [^String address]
-  (fn [^UnleashContext$Builder bldr]
-    (.remoteAddress bldr address)))
+(defn remote-address
+  "Expects a remote address (IP address). Used by RemoteAddressStrategy.
+  Returns a function that expects an UnleashContext$Builder, and sets the remoteAddress property of the builder."
+  [^String address]
+  (fn [^UnleashContext$Builder builder]
+    (.remoteAddress builder address)))
 
-(defn add-property [^String name ^String value]
-  (fn [^UnleashContext$Builder bldr]
-    (.addProperty bldr name value)))
-
+(defn add-property
+  "Expects a property name-value pair.
+  Returns a function that expects an UnleashContext$Builder, and adds the key-value pair to the context's properties."
+  [^String name ^String value]
+  (fn [^UnleashContext$Builder builder]
+    (.addProperty builder name value)))

--- a/src/unleash_client_clojure/fake.clj
+++ b/src/unleash_client_clojure/fake.clj
@@ -19,18 +19,22 @@
      (if (fn? fallback)
        (.isEnabled this ^String toggle-name ^UnleashContext context (BiFunctionWrapper. fallback))
        (.isEnabled this ^String toggle-name ^UnleashContext context ^boolean fallback))))
+
   (get-variant
     ([this toggle-name]
      (OptionalPayloadVariant. (.getVariant this ^String toggle-name)))
     ([this toggle-name default-variant]
      (OptionalPayloadVariant. (.getVariant this ^String toggle-name ^Variant default-variant))))
+
   (get-variant-with-context
     ([this toggle-name context]
      (OptionalPayloadVariant. (.getVariant this ^String toggle-name ^UnleashContext context)))
     ([this toggle-name context default-variant]
      (OptionalPayloadVariant. (.getVariant this ^String toggle-name ^UnleashContext context ^Variant default-variant))))
+
   (get-toggle-definition [this toggle-name]
     (throw (UnsupportedOperationException.)))
+
   (get-feature-toggle-names [this]
     (vec (.getFeatureToggleNames this))))
 

--- a/src/unleash_client_clojure/fake.clj
+++ b/src/unleash_client_clojure/fake.clj
@@ -1,6 +1,6 @@
 (ns unleash-client-clojure.fake
-  (:require [unleash-client-clojure.unleash :as u]
-            [unleash_client_clojure.util])
+  "Creating FakeUnleash instances that adhere to the IUnleash protocol."
+  (:require [unleash-client-clojure.unleash :as u])
   (:import [unleash_client_clojure.variant OptionalPayloadVariant]
            [no.finn.unleash FakeUnleash]
            [no.finn.unleash UnleashContext Variant]
@@ -38,5 +38,7 @@
   (get-feature-toggle-names [this]
     (vec (.getFeatureToggleNames this))))
 
-(defn build [] (FakeUnleash.))
-
+(defn build
+  "Returns an instance of FakeUnleash for unit test purposes."
+  []
+  (FakeUnleash.))

--- a/src/unleash_client_clojure/subscriber.clj
+++ b/src/unleash_client_clojure/subscriber.clj
@@ -32,20 +32,24 @@
     (toggles-backed-up))
   (^void toggleBackupRestored [_ ^ToggleCollection collection]
     (toggle-backup-restored collection)))
-                          
+
 (defn- no-op [_])
 
-(defn build [{:keys [on-error on-event on-ready toggle-evaluated
-                     toggles-fetched client-metrics client-registered
-                     toggles-backed-up toggle-backup-restored]
-              :or {on-error no-op
-                   on-event no-op
-                   toggle-evaluated no-op
-                   toggles-fetched no-op
-                   client-metrics no-op
-                   client-registered no-op
-                   toggles-backed-up no-op
-                   toggle-backup-restored no-op}}]
-                   
+(defn build
+  "Expects a map of event types to event handlers.
+  Returns an instance of UnleashSubscriber which would be called when the internal state of the Unleash client changes.
+  This instance can be attached to the Unleash client by using unleash-client-clojure.builder/subscriber."
+  [{:keys [on-error on-event on-ready toggle-evaluated
+           toggles-fetched client-metrics client-registered
+           toggles-backed-up toggle-backup-restored]
+    :or   {on-error               no-op
+           on-event               no-op
+           toggle-evaluated       no-op
+           toggles-fetched        no-op
+           client-metrics         no-op
+           client-registered      no-op
+           toggles-backed-up      no-op
+           toggle-backup-restored no-op}}]
+
   (Subscriber. on-error on-event on-ready toggle-evaluated toggles-fetched
                client-metrics client-registered toggles-backed-up toggle-backup-restored))

--- a/src/unleash_client_clojure/subscriber.clj
+++ b/src/unleash_client_clojure/subscriber.clj
@@ -1,4 +1,5 @@
 (ns unleash-client-clojure.subscriber
+  "Create a Clojure wrapper over the UnleashSubscriber interface."
   (:import [no.finn.unleash.event UnleashSubscriber UnleashEvent UnleashReady ToggleEvaluated]
            [no.finn.unleash.repository FeatureToggleResponse ToggleCollection]
            [no.finn.unleash.metric ClientMetrics ClientRegistration]

--- a/src/unleash_client_clojure/unleash.clj
+++ b/src/unleash_client_clojure/unleash.clj
@@ -10,18 +10,22 @@
            [unleash_client_clojure.variant OptionalPayloadVariant]))
 
 (defprotocol IUnleash
+  "An abstraction of an Unleash client."
   (enabled?
     [this ^String toggle-name]
     [this ^String toggle-name fallback]
-    [this ^String toggle-name ^UnleashContext context fallback])
+    [this ^String toggle-name ^UnleashContext context fallback]
+    "Returns 'true' whether the toggle is enabled, 'false' otherwise. Can also provide a custom fallback option in case
+    the toggle isn't found via 'fallback', or a toggle evaluation context via 'context'.")
   (get-variant
     [this ^String toggle-name]
-    [this ^String toggle-name ^Variant default-variant])
+    [this ^String toggle-name ^Variant default-variant] "Returns the instance's variant, useful for unit tests.")
   (get-variant-with-context
     [this ^String toggle-name ^UnleashContext context]
-    [this ^String toggle-name ^UnleashContext context ^Variant default-variant])
-  (get-toggle-definition [this toggle-name])
-  (get-feature-toggle-names [this]))
+    [this ^String toggle-name ^UnleashContext context ^Variant default-variant]
+    "Returns the instance's variant while evaluating the supplied context, useful for unit tests.")
+  (get-toggle-definition [this toggle-name] "Returns a toggle's definition.")
+  (get-feature-toggle-names [this] "Returns a sequence of all the feature toggles' names known to this client."))
 
 (extend-protocol IUnleash
   DefaultUnleash
@@ -53,11 +57,15 @@
     (vec (.getFeatureToggleNames this))))
 
 (defn build
-  [& fs]
-  (DefaultUnleash. (apply builder/build fs)
+  "Expects to be applied with a variadic number of builder-setter functions.
+  Returns an instance of DefaultUnleash that supports AppsFlyer-specific strategies."
+  [& builder-param-setters]
+  (DefaultUnleash. (apply builder/build builder-param-setters)
                    (into-array Strategy [])))
 
 (defn build-with-custom-strategies
-  [strategies & fs]
-  (DefaultUnleash. (apply builder/build fs)
+  "Expects to be applied with a sequence of strategies and a variadic number of builder-setter functions.
+  Returns an instance of DefaultUnleash that supports the provided strategies."
+  [strategies & builder-param-setters]
+  (DefaultUnleash. (apply builder/build builder-param-setters)
                    (into-array Strategy strategies)))

--- a/src/unleash_client_clojure/util.clj
+++ b/src/unleash_client_clojure/util.clj
@@ -5,4 +5,3 @@
   BiFunction
   (apply [_ toggle-name context]
     (f toggle-name context)))
-

--- a/src/unleash_client_clojure/variant.clj
+++ b/src/unleash_client_clojure/variant.clj
@@ -5,7 +5,7 @@
 
 (defprotocol IVariant
   "A protocol to bridge the Java class no.finn.unleash.Variant into Clojure.
-  The class is used in unit tests to change the state of a FakeUnleash."
+  The class is used in unit tests to change the state of a FakeUnleash instance."
   (variant-enabled? [this] "Returns whether the variant is active or not.")
   (get-name [this] "Returns the variant's name.")
   (payload [this] "Returns the variant's payload, if it's present and the variant is enabled, otherwise returns nil.")
@@ -30,5 +30,3 @@
   (get-value [this]
     (when-let [payload ^Payload (.payload this)]
       (.getValue payload))))
-
-

--- a/src/unleash_client_clojure/variant.clj
+++ b/src/unleash_client_clojure/variant.clj
@@ -4,11 +4,13 @@
            [java.util Optional]))
 
 (defprotocol IVariant
-  (variant-enabled? [this])
-  (get-name [this])
-  (payload [this])
-  (get-type [this])
-  (get-value [this]))
+  "A protocol to bridge the Java class no.finn.unleash.Variant into Clojure.
+  The class is used in unit tests to change the state of a FakeUnleash."
+  (variant-enabled? [this] "Returns whether the variant is active or not.")
+  (get-name [this] "Returns the variant's name.")
+  (payload [this] "Returns the variant's payload, if it's present and the variant is enabled, otherwise returns nil.")
+  (get-type [this] "Returns the variant's type if it's present and the variant is enabled, otherwise returns nil.")
+  (get-value [this] "Returns the variant's value, if present, otherwise returns nil."))
 
 (deftype OptionalPayloadVariant [^Variant variant]
   IVariant

--- a/test/unleash_client_clojure/builder_test.clj
+++ b/test/unleash_client_clojure/builder_test.clj
@@ -9,31 +9,31 @@
 
 (deftest builder
   (testing "building unleash sets correct config"
-    (let [app-name "app"
+    (let [app-name    "app"
           instance-id "some-instance"
-          api "http://127.0.0.1"
+          api         "http://127.0.0.1"
           backup-path (s/join File/separatorChar
                               [(System/getProperty "java.io.tmpdir") (str (rand-int 100) ".json")])
-          context (c/build (c/app-name "some-app"))
-          subscriber (subscriber/build {})
-          config (b/build
-                   (b/app-name app-name)
-                   (b/instance-id instance-id)
-                   (b/unleash-api api)
-                   (b/custom-http-header "header-name" "header-value")
-                   (b/send-metrics-interval 42)
-                   (b/fetch-toggles-interval 43)
-                   (b/synchronous-fetch-on-initialisation true)
-                   (b/enable-proxy-authentication-by-jvm-properties)
-                   (b/backup-file backup-path)
-                   (b/environment "staging")
-                   (b/custom-http-header-provider
-                     (reify CustomHttpHeadersProvider
-                       (getCustomHeaders [_] {"foo" "bar"})))
-                   (b/unleash-context-provider
-                     (reify UnleashContextProvider
-                       (getContext [_] context)))
-                   (b/subscriber subscriber))]
+          context     (c/build (c/app-name "some-app"))
+          subscriber  (subscriber/build {})
+          config      (b/build
+                        (b/app-name app-name)
+                        (b/instance-id instance-id)
+                        (b/unleash-api api)
+                        (b/custom-http-header "header-name" "header-value")
+                        (b/send-metrics-interval 42)
+                        (b/fetch-toggles-interval 43)
+                        (b/synchronous-fetch-on-initialisation true)
+                        (b/enable-proxy-authentication-by-jvm-properties)
+                        (b/backup-file backup-path)
+                        (b/environment "staging")
+                        (b/custom-http-header-provider
+                          (reify CustomHttpHeadersProvider
+                            (getCustomHeaders [_] {"foo" "bar"})))
+                        (b/unleash-context-provider
+                          (reify UnleashContextProvider
+                            (getContext [_] context)))
+                        (b/subscriber subscriber))]
 
       (is (= {"header-name" "header-value"}
              (.getCustomHttpHeaders config)))

--- a/test/unleash_client_clojure/context_test.clj
+++ b/test/unleash_client_clojure/context_test.clj
@@ -5,14 +5,14 @@
 (deftest builder
   (testing "building unleash context sets correct config"
     (let [context (c/build
-                    (c/app-name "app") 
-                    (c/environment "env") 
-                    (c/user-id "userId") 
-                    (c/session-id "42") 
-                    (c/remote-address "1.2.2.1") 
-                    (c/add-property "foo" "bar") 
-                    (c/add-property "bar" "baz"))] 
-                   
+                    (c/app-name "app")
+                    (c/environment "env")
+                    (c/user-id "userId")
+                    (c/session-id "42")
+                    (c/remote-address "1.2.2.1")
+                    (c/add-property "foo" "bar")
+                    (c/add-property "bar" "baz"))]
+
       (is (= "app"
              (c/get-app-name context)))
       (is (= "env"

--- a/test/unleash_client_clojure/unleash_test.clj
+++ b/test/unleash_client_clojure/unleash_test.clj
@@ -9,35 +9,34 @@
 (deftest is-enabled
   (let [fu (FakeUnleash.)]
     (testing "enabled returns true"
-        (.enableAll fu)
-        (is (true? (u/enabled? fu "foo"))))
+      (.enableAll fu)
+      (is (true? (u/enabled? fu "foo"))))
     (testing "enabled returns false"
-        (.resetAll fu)
-        (is (false? (u/enabled? fu "foo"))))
+      (.resetAll fu)
+      (is (false? (u/enabled? fu "foo"))))
     (testing "enabled returns true/false"
-        (.enable fu (into-array String ["foo"]))
-        (is (true? (u/enabled? fu "foo")))
-        (.disable fu (into-array String ["foo"]))
-        (is (false? (u/enabled? fu "foo"))))
+      (.enable fu (into-array String ["foo"]))
+      (is (true? (u/enabled? fu "foo")))
+      (.disable fu (into-array String ["foo"]))
+      (is (false? (u/enabled? fu "foo"))))
     (testing "enabled returns false for unknwon"
-        (is (false? (u/enabled? fu "bar"))))))
-    
+      (is (false? (u/enabled? fu "bar"))))))
+
 (deftest variants
   (let [fu (FakeUnleash.)]
     (testing "get-variant"
-        (.enable fu (into-array String ["variant1"]))
-        (let [payload (Payload. "string" "secret-string")]
-          (.setVariant fu "variant1" (Variant. "red" payload true))
-          (let [v (u/get-variant fu "variant1")]
-            (is (true? (v/variant-enabled? v)))
-            (is (= "red" (v/get-name v)))
-            (is (= payload (v/payload v)))
-            (is (= "string" (v/get-type v)))
-            (is (= "secret-string" (v/get-value v))))
-          (let [v (u/get-variant fu "not-there")]
-            (is (false? (v/variant-enabled? v)))
-            (is (= "disabled" (v/get-name v)))
-            (is (nil? (v/payload v)))
-            (is (nil? (v/get-type v)))
-            (is (nil? (v/get-value v))))))))
-
+      (.enable fu (into-array String ["variant1"]))
+      (let [payload (Payload. "string" "secret-string")]
+        (.setVariant fu "variant1" (Variant. "red" payload true))
+        (let [v (u/get-variant fu "variant1")]
+          (is (true? (v/variant-enabled? v)))
+          (is (= "red" (v/get-name v)))
+          (is (= payload (v/payload v)))
+          (is (= "string" (v/get-type v)))
+          (is (= "secret-string" (v/get-value v))))
+        (let [v (u/get-variant fu "not-there")]
+          (is (false? (v/variant-enabled? v)))
+          (is (= "disabled" (v/get-name v)))
+          (is (nil? (v/payload v)))
+          (is (nil? (v/get-type v)))
+          (is (nil? (v/get-value v))))))))


### PR DESCRIPTION
In this PR:
1. Added docstrings to clarify how the library can be used.
2. Changed a few variable names to be more descriptive.