### PR TITLE
Work around log4j cve

### DIFF
--- a/.github/workflows/build_test_pr.yml
+++ b/.github/workflows/build_test_pr.yml
@@ -1,0 +1,60 @@
+name: "Pull Request Build & Test"
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Restore local Maven repository from cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles( 'project.clj' ) }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Validate SNAPSHOT version
+        env:
+          SNAPSHOT_REGEX: ^[0-9]{1,2}[.][0-9]{1,2}[.][0-9]{1,3}-SNAPSHOT$
+        if: github.ref != 'refs/heads/master'
+        run: |
+          lein pom
+          export VERSION=$(less pom.xml | grep "<version>" | head -1 | cut -d ">" -f2 | cut -d "<" -f1)
+          echo "Version is:" $VERSION
+          if [[ !("$VERSION" =~ $SNAPSHOT_REGEX) ]]
+          then
+            echo "Version isn't a SNAPSHOT version:" $VERSION
+            exit 0
+          fi
+      - name: Lint
+        run: lein lint
+
+  test:
+    needs: build
+    runs-on: ubuntu-18.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Restore local Maven repository from cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles( 'project.clj' ) }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Unit and integration tests
+        run: lein test :all

--- a/.github/workflows/build_test_pr.yml
+++ b/.github/workflows/build_test_pr.yml
@@ -35,7 +35,7 @@ jobs:
             echo "Version isn't a SNAPSHOT version:" $VERSION
             exit 0
           fi
-      - name: Lint
+      - name: lint
         run: lein lint
 
   test:

--- a/.github/workflows/ci_branch.yml
+++ b/.github/workflows/ci_branch.yml
@@ -36,12 +36,8 @@ jobs:
             echo "Version isn't a SNAPSHOT version:" $VERSION
             exit 0
           fi
-      - name: Lint
-        uses: DeLaGuardo/clojure-lint-action@v1
-        with:
-          clj-kondo-args: --lint src test --cache false
-          check-name: clj-kondo liniting report
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: lint
+        run: lein lint
 
   test:
     needs: build

--- a/.github/workflows/ci_branch.yml
+++ b/.github/workflows/ci_branch.yml
@@ -1,0 +1,109 @@
+name: "Push CI - branches"
+
+on:
+  push:
+    branches-ignore:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Restore local Maven repository from cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles( 'project.clj' ) }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Validate SNAPSHOT version
+        env:
+          SNAPSHOT_REGEX: ^[0-9]{1,2}[.][0-9]{1,2}[.][0-9]{1,3}-SNAPSHOT$
+        if: github.ref != 'refs/heads/master'
+        run: |
+          lein pom
+          export VERSION=$(less pom.xml | grep "<version>" | head -1 | cut -d ">" -f2 | cut -d "<" -f1)
+          echo "Version is:" $VERSION
+          if [[ !("$VERSION" =~ $SNAPSHOT_REGEX) ]]
+          then
+            echo "Version isn't a SNAPSHOT version:" $VERSION
+            exit 0
+          fi
+      - name: Lint
+        uses: DeLaGuardo/clojure-lint-action@v1
+        with:
+          clj-kondo-args: --lint src test --cache false
+          check-name: clj-kondo liniting report
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  test:
+    needs: build
+    runs-on: ubuntu-18.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Restore local Maven repository from cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles( 'project.clj' ) }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Unit and Integration tests
+        run: lein eftest :all
+      - name: Publish unit and integration test results
+        uses: EnricoMi/publish-unit-test-result-action@v1.6
+        if: always()
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: "target/junit.xml"
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-18.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Restore local Maven repository from cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles( 'project.clj' ) }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Deploy SNAPSHOT version
+        env:
+          SNAPSHOT_REGEX: ^[0-9]{1,2}[.][0-9]{1,2}[.][0-9]{1,3}-SNAPSHOT$
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLOJARS_USERNAME: ${{ secrets.CLOJARS_USERNAME }}
+          CLOJARS_PASSWORD: ${{ secrets.CLOJARS_PASSWORD }}
+        run: |
+          git config --global user.name "github-actions-bot"
+          git config --global user.email "<>"
+          lein pom
+          export SNAPSHOT_VERSION=$(less pom.xml | grep "<version>" | head -1 | cut -d ">" -f2 | cut -d "<" -f1)
+          echo "SNAPSHOT version is:" $SNAPSHOT_VERSION
+          if [[ !("$SNAPSHOT_VERSION" =~ $SNAPSHOT_REGEX) ]]
+          then
+            echo "Version isn't a SNAPSHOT version:" $SNAPSHOT_VERSION ", skipping deployment to Clojars..."
+            exit 0
+          fi
+          lein deploy
+          echo "SNAPSHOT version:" $SNAPSHOT_VERSION"; commit: "${{github.sha}}"; successfully deployed to Clojars"

--- a/.github/workflows/ci_master.yml
+++ b/.github/workflows/ci_master.yml
@@ -36,12 +36,8 @@ jobs:
             echo "Version isn't a SNAPSHOT version:" $VERSION
             exit 0
           fi
-      - name: Lint
-        uses: DeLaGuardo/clojure-lint-action@v1
-        with:
-          clj-kondo-args: --lint src test --cache false
-          check-name: clj-kondo liniting report
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: lint
+        run: lein lint
 
   test:
     needs: build

--- a/.github/workflows/ci_master.yml
+++ b/.github/workflows/ci_master.yml
@@ -1,0 +1,117 @@
+name: "Push CI - master"
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Restore local Maven repository from cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles( 'project.clj' ) }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Validate SNAPSHOT version
+        env:
+          SNAPSHOT_REGEX: ^[0-9]{1,2}[.][0-9]{1,2}[.][0-9]{1,3}-SNAPSHOT$
+        if: github.ref != 'refs/heads/master'
+        run: |
+          lein pom
+          export VERSION=$(less pom.xml | grep "<version>" | head -1 | cut -d ">" -f2 | cut -d "<" -f1)
+          echo "Version is:" $VERSION
+          if [[ !("$VERSION" =~ $SNAPSHOT_REGEX) ]]
+          then
+            echo "Version isn't a SNAPSHOT version:" $VERSION
+            exit 0
+          fi
+      - name: Lint
+        uses: DeLaGuardo/clojure-lint-action@v1
+        with:
+          clj-kondo-args: --lint src test --cache false
+          check-name: clj-kondo liniting report
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  test:
+    needs: build
+    runs-on: ubuntu-18.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Restore local Maven repository from cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles( 'project.clj' ) }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Unit and Integration tests
+        run: lein eftest :all
+      - name: Publish unit and integration test results
+        uses: EnricoMi/publish-unit-test-result-action@v1.6
+        if: always()
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          files: "target/junit.xml"
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-18.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Restore local Maven repository from cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles( 'project.clj' ) }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Deploy release version
+        env:
+          RELEASE_REGEX: ^[0-9]{1,2}[.][0-9]{1,2}[.][0-9]{1,3}$
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLOJARS_USERNAME: ${{ secrets.CLOJARS_USERNAME }}
+          CLOJARS_PASSWORD: ${{ secrets.CLOJARS_PASSWORD }}
+        run: |
+          git config --global user.name "github-actions-bot"
+          git config --global user.email "<>"
+          git config --global push.followTags true
+          lein pom
+          export ORIGINAL_VERSION=$(less pom.xml | grep "<version>" | head -1 | cut -d ">" -f2 | cut -d "<" -f1)
+          echo "Original version is:" $ORIGINAL_VERSION
+          lein change version leiningen.release/bump-version release
+          lein do vcs commit, install
+          lein pom
+          export RELEASE_VERSION=$(less pom.xml | grep "<version>" | head -1 | cut -d ">" -f2 | cut -d "<" -f1)
+          echo "Release version is:" $RELEASE_VERSION
+          if [[ !("$RELEASE_VERSION" =~ $RELEASE_REGEX) ]]
+          then
+            echo "Version isn't a release version:" $RELEASE_VERSION ", skipping deployment to Clojars..."
+            exit 0
+          fi
+          git tag -a $RELEASE_VERSION -m "Release version $RELEASE_VERSION"
+          git push origin master
+          lein deploy
+          echo "Release version:" $RELEASE_VERSION"; commit: "${{github.sha}}"; successfully deployed to Clojars"

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ pom.xml.asc
 .settings
 .project
 .idea
+.bloop
+.metals

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,6 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
-## [Unreleased]
+## [0.3.0]
 ### Changed
-- Add a new arity to `make-widget-async` to provide a different widget shape.
-
-## [0.1.1] - 2020-08-20
-### Changed
-- Documentation on how to make the widgets.
-
-### Removed
-- `make-widget-sync` - we're all async, all the time.
-
-### Fixed
-- Fixed widget maker to keep working when daylight savings switches over.
-
-## 0.1.0 - 2020-08-20
-### Added
-- Files from the new template.
-- Widget maker public API - `make-widget-sync`.
-
-[Unreleased]: https://github.com/your-name/unleash-client-clojure/compare/0.1.1...HEAD
-[0.1.1]: https://github.com/your-name/unleash-client-clojure/compare/0.1.0...0.1.1
+- removed direct log dependency originating upstream.

--- a/project.clj
+++ b/project.clj
@@ -18,5 +18,6 @@
                    :aliases      {"clj-kondo" ["run" "-m" "clj-kondo.main"]
                                   "lint"      ["run" "-m" "clj-kondo.main" "--lint" "src" "test"]}
                    :plugins      [[lein-ancient "1.0.0-RC3"]
-                                  [lein-cloverage "1.2.2"]]
+                                  [lein-cloverage "1.2.2"]
+                                  [lein-eftest "0.5.9"]]
                    :global-vars  {*warn-on-reflection* true}}})

--- a/project.clj
+++ b/project.clj
@@ -1,14 +1,23 @@
-(defproject unleash-client-clojure "0.2.1"
+(defproject unleash-client-clojure "0.3.0"
   :description "A Clojure library wrapping https://github.com/Unleash/unleash-client-java"
   :url "https://github.com/AppsFlyer/unleash-client-clojure"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url  "https://www.eclipse.org/legal/epl-2.0/"}
-  :dependencies [[no.finn.unleash/unleash-client-java "3.3.3"]]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.1"]
+  :deploy-repositories []
+  ["releases" {:url "https://repo.clojars.org"
+               :username :env/clojars_username
+               :password :env/clojars_password
+               :sign-releases false}] 
+  ["snapshots" {:url "https://repo.clojars.org"
+                :username :env/clojars_username
+                :password :env/clojars_password
+                :sign-releases false}]
+  :dependencies [[no.finn.unleash/unleash-client-java "3.3.4" :exclusions [org.apache.logging.log4j/log4j-api]]]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.3"]
                                   [clj-kondo "RELEASE"]
-                                  [org.apache.logging.log4j/log4j-core "2.11.2"]]
+                                  [org.apache.logging.log4j/log4j-core "2.15.0"]]
                    :aliases      {"clj-kondo" ["run" "-m" "clj-kondo.main"]
                                   "lint"      ["run" "-m" "clj-kondo.main" "--lint" "src" "test"]}
-                   :plugins      [[lein-ancient "0.6.15"]
-                                  [lein-cloverage "1.2.0"]]
+                   :plugins      [[lein-ancient "1.0.0-RC3"]
+                                  [lein-cloverage "1.2.2"]]
                    :global-vars  {*warn-on-reflection* true}}})

--- a/project.clj
+++ b/project.clj
@@ -3,15 +3,14 @@
   :url "https://github.com/AppsFlyer/unleash-client-clojure"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url  "https://www.eclipse.org/legal/epl-2.0/"}
-  :deploy-repositories []
-  ["releases" {:url "https://repo.clojars.org"
-               :username :env/clojars_username
-               :password :env/clojars_password
-               :sign-releases false}] 
-  ["snapshots" {:url "https://repo.clojars.org"
-                :username :env/clojars_username
-                :password :env/clojars_password
-                :sign-releases false}]
+  :deploy-repositories [["releases" {:url "https://repo.clojars.org"
+                                     :username :env/clojars_username
+                                     :password :env/clojars_password
+                                     :sign-releases false}] 
+                        ["snapshots" {:url "https://repo.clojars.org"
+                                      :username :env/clojars_username
+                                      :password :env/clojars_password
+                                      :sign-releases false}]]
   :dependencies [[no.finn.unleash/unleash-client-java "3.3.4" :exclusions [org.apache.logging.log4j/log4j-api]]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.3"]
                                   [clj-kondo "RELEASE"]

--- a/src/unleash_client_clojure/fake.clj
+++ b/src/unleash_client_clojure/fake.clj
@@ -32,7 +32,7 @@
     ([this toggle-name context default-variant]
      (OptionalPayloadVariant. (.getVariant this ^String toggle-name ^UnleashContext context ^Variant default-variant))))
 
-  (get-toggle-definition [this toggle-name]
+  (get-toggle-definition [_this _toggle-name]
     (throw (UnsupportedOperationException.)))
 
   (get-feature-toggle-names [this]


### PR DESCRIPTION
upstream log4j dependency was updated in #146 alas was not backported
yet to 3.x versions. This change removes its dependency altogether.
Since it is better practice to not depend on the logging library directly
at all (but rather on a logging facade), and since upstream already
depends on a logging facade, we are better off.