### PR TITLE
restore log4j-api to 2.15.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject unleash-client-clojure "0.3.0"
+(defproject unleash-client-clojure "0.3.1"
   :description "A Clojure library wrapping https://github.com/Unleash/unleash-client-java"
   :url "https://github.com/AppsFlyer/unleash-client-clojure"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
@@ -11,7 +11,8 @@
                                       :username :env/clojars_username
                                       :password :env/clojars_password
                                       :sign-releases false}]]
-  :dependencies [[no.finn.unleash/unleash-client-java "3.3.4" :exclusions [org.apache.logging.log4j/log4j-api]]]
+  :dependencies [[no.finn.unleash/unleash-client-java "3.3.4"]
+                 [org.apache.logging.log4j/log4j-api "2.15.0"]] ; pending backport of the java client to 3.x. see https://github.com/Unleash/unleash-client-java/pull/146#issuecomment-991722582
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.3"]
                                   [clj-kondo "RELEASE"]
                                   [org.apache.logging.log4j/log4j-core "2.15.0"]]


### PR DESCRIPTION
log4j-api is required by the java client, hence it must be available at runtime. here's the exception I ran into without the api:

```
java.lang.NoClassDefFoundError: org/apache/logging/log4j/LogManager
 at no.finn.unleash.util.UnleashScheduledExecutorImpl.<clinit> (UnleashScheduledExecutorImpl.java:10)
    java.util.Optional.orElseGet (Optional.java:362)
    no.finn.unleash.util.UnleashConfig$Builder.build (UnleashConfig.java:337)
    unleash_client_clojure.builder$build.invokeStatic (builder.clj:20)
    unleash_client_clojure.builder$build.doInvoke (builder.clj:7)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.core$apply.invokeStatic (core.clj:665)
    clojure.core$apply.invoke (core.clj:660)
    unleash_client_clojure.unleash$build_with_custom_strategies.invokeStatic (unleash.clj:70)
    unleash_client_clojure.unleash$build_with_custom_strategies.doInvoke (unleash.clj:66)
    clojure.lang.RestFn.applyTo (RestFn.java:139)
    clojure.core$apply.invokeStatic (core.clj:673)
    clojure.core$partial$fn__5839.doInvoke (core.clj:2622)
    clojure.lang.RestFn.applyTo (RestFn.java:146)
    clojure.core$apply.invokeStatic (core.clj:665)
    clojure.core$apply.invoke (core.clj:660)
    af_clj_unleash.unleash$init.invokeStatic (unleash.clj:72)
    af_clj_unleash.unleash$init.invoke (unleash.clj:65)
    af_clj_unleash.strategies.integration_test$fn__3233.invokeStatic (integration_test.clj:40)
    af_clj_unleash.strategies.integration_test/fn (integration_test.clj:37)
    clojure.test$test_var$fn__9737.invoke (test.clj:717)
    clojure.test$test_var.invokeStatic (test.clj:717)
    clojure.test$test_var.invoke (test.clj:708)
    cursive.tests.runner$test_vars$fn__190$fn__199.invoke (run-tests4450176336353371250.clj:36)
    clojure.test$default_fixture.invokeStatic (test.clj:687)
    clojure.test$default_fixture.invoke (test.clj:683)
    cursive.tests.runner$test_vars$fn__190.invoke (run-tests4450176336353371250.clj:36)
    af_clj_unleash.strategies.integration_test$init_meters.invokeStatic (integration_test.clj:33)
    af_clj_unleash.strategies.integration_test$init_meters.invoke (integration_test.clj:30)
    clojure.test$compose_fixtures$fn__9731$fn__9732.invoke (test.clj:694)
    clojure.test$default_fixture.invokeStatic (test.clj:687)
    clojure.test$default_fixture.invoke (test.clj:683)
    clojure.test$compose_fixtures$fn__9731.invoke (test.clj:694)
    cursive.tests.runner$test_vars.invokeStatic (run-tests4450176336353371250.clj:29)
    cursive.tests.runner$test_vars.invoke (run-tests4450176336353371250.clj:21)
    cursive.tests.runner$test_all_vars.invokeStatic (run-tests4450176336353371250.clj:41)
    cursive.tests.runner$test_all_vars.invoke (run-tests4450176336353371250.clj:38)
    cursive.tests.runner$test_ns.invokeStatic (run-tests4450176336353371250.clj:68)
    cursive.tests.runner$test_ns.invoke (run-tests4450176336353371250.clj:52)
    cursive.tests.runner$run_tests$fn__224.invoke (run-tests4450176336353371250.clj:76)
    clojure.core$map$fn__5866.invoke (core.clj:2753)
    clojure.lang.LazySeq.sval (LazySeq.java:42)
    clojure.lang.LazySeq.seq (LazySeq.java:51)
    clojure.lang.Cons.next (Cons.java:39)
    clojure.lang.RT.boundedLength (RT.java:1792)
    clojure.lang.RestFn.applyTo (RestFn.java:130)
    clojure.core$apply.invokeStatic (core.clj:667)
    clojure.core$apply.invoke (core.clj:660)
    cursive.tests.runner$run_tests.invokeStatic (run-tests4450176336353371250.clj:76)
    cursive.tests.runner$run_tests.invoke (run-tests4450176336353371250.clj:72)
    cursive.tests.runner$eval3281$fn__3317.invoke (run-tests4450176336353371250.clj:81)
    cursive.tests.runner$eval3281.invokeStatic (run-tests4450176336353371250.clj:81)
    cursive.tests.runner$eval3281.invoke (run-tests4450176336353371250.clj:81)
    clojure.lang.Compiler.eval (Compiler.java:7177)
    clojure.lang.Compiler.eval (Compiler.java:7167)
    clojure.lang.Compiler.load (Compiler.java:7636)
    clojure.lang.Compiler.loadFile (Compiler.java:7574)
    clojure.main$load_script.invokeStatic (main.clj:475)
    clojure.main$script_opt.invokeStatic (main.clj:535)
    clojure.main$script_opt.invoke (main.clj:530)
    clojure.main$main.invokeStatic (main.clj:664)
    clojure.main$main.doInvoke (main.clj:616)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.lang.Var.applyTo (Var.java:705)
    clojure.main.main (main.java:40)
```