### PR TITLE
Use latest unleash sdk

### DIFF
--- a/dev-resources/log4j.xml
+++ b/dev-resources/log4j.xml
@@ -10,11 +10,11 @@
 		</layout>
 	</appender>
 	<!-- Insert here your own base-package -->
-	<logger name="no.finn.unleash">
+	<logger name="io.getunleash">
 		<level value="DEBUG" />
 		<appender-ref ref="CONSOLE" />
 	</logger>
-	<logger name="no.finn.unleash.repository.ToggleBackupHandlerFile">
+	<logger name="io.getunleash.repository.ToggleBackupHandlerFile">
 		<level value="DEBUG" />
 		<appender-ref ref="CONSOLE" />
 	</logger>

--- a/project.clj
+++ b/project.clj
@@ -11,11 +11,11 @@
                                       :username :env/clojars_username
                                       :password :env/clojars_password
                                       :sign-releases false}]]
-  :dependencies [[no.finn.unleash/unleash-client-java "4.4.1"]]
+  :dependencies [[io.getunleash/unleash-client-java "5.0.3"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.3"]
                                   [clj-kondo "RELEASE"]
-                                  [org.apache.logging.log4j/log4j-core "2.17.0"]
-                                  [org.apache.logging.log4j/log4j-api "2.17.0"]
+                                  [org.apache.logging.log4j/log4j-core "2.17.1"]
+                                  [org.apache.logging.log4j/log4j-api "2.17.1"]
                                   [org.slf4j/slf4j-log4j12 "1.7.32"]]
                    :aliases      {"clj-kondo" ["run" "-m" "clj-kondo.main"]
                                   "lint"      ["run" "-m" "clj-kondo.main" "--lint" "src" "test"]}

--- a/src/unleash_client_clojure/builder.clj
+++ b/src/unleash_client_clojure/builder.clj
@@ -1,11 +1,11 @@
 (ns unleash-client-clojure.builder
   "Create and configure builders that build instances of UnleashConfig."
-  (:import [no.finn.unleash CustomHttpHeadersProvider UnleashContextProvider]
-           [no.finn.unleash.util UnleashConfig UnleashConfig$Builder UnleashScheduledExecutor]
-           [no.finn.unleash.event UnleashSubscriber]
-           [no.finn.unleash.strategy Strategy]
-           [no.finn.unleash.repository ToggleBootstrapProvider]
-           [java.net Proxy]))
+  (:import (io.getunleash CustomHttpHeadersProvider UnleashContextProvider)
+           (io.getunleash.util UnleashConfig UnleashConfig$Builder UnleashScheduledExecutor)
+           (io.getunleash.event UnleashSubscriber)
+           (io.getunleash.strategy Strategy)
+           (io.getunleash.repository ToggleBootstrapProvider)
+           (java.net Proxy)))
 
 (defn build
   "Expects to be applied with a variadic number of arguments, each of which is a function that expects an

--- a/src/unleash_client_clojure/context.clj
+++ b/src/unleash_client_clojure/context.clj
@@ -1,6 +1,6 @@
 (ns unleash-client-clojure.context
   "Create and configure builders that build instances of UnleashContext."
-  (:import [no.finn.unleash UnleashContext UnleashContext$Builder]))
+  (:import (io.getunleash UnleashContext UnleashContext$Builder)))
 
 (defn build
   "Expects to be applied with a variadic number of arguments, each of which is a function that expects an

--- a/src/unleash_client_clojure/fake.clj
+++ b/src/unleash_client_clojure/fake.clj
@@ -1,10 +1,10 @@
 (ns unleash-client-clojure.fake
   "Creating FakeUnleash instances that adhere to the IUnleash protocol."
   (:require [unleash-client-clojure.unleash :as u])
-  (:import [unleash_client_clojure.variant OptionalPayloadVariant]
-           [no.finn.unleash FakeUnleash]
-           [no.finn.unleash UnleashContext Variant]
-           [unleash_client_clojure.util BiFunctionWrapper]))
+  (:import (unleash_client_clojure.variant OptionalPayloadVariant)
+           (io.getunleash FakeUnleash)
+           (io.getunleash UnleashContext Variant)
+           (unleash_client_clojure.util BiFunctionWrapper)))
 
 (extend-protocol u/IUnleash
   FakeUnleash

--- a/src/unleash_client_clojure/subscriber.clj
+++ b/src/unleash_client_clojure/subscriber.clj
@@ -1,9 +1,9 @@
 (ns unleash-client-clojure.subscriber
   "Create a Clojure wrapper over the UnleashSubscriber interface."
-  (:import [no.finn.unleash.event UnleashSubscriber UnleashEvent UnleashReady ToggleEvaluated]
-           [no.finn.unleash.repository FeatureToggleResponse ToggleCollection]
-           [no.finn.unleash.metric ClientMetrics ClientRegistration]
-           [no.finn.unleash UnleashException]))
+  (:import (io.getunleash.event UnleashSubscriber UnleashEvent UnleashReady ToggleEvaluated)
+           (io.getunleash.repository FeatureToggleResponse ToggleCollection)
+           (io.getunleash.metric ClientMetrics ClientRegistration)
+           (io.getunleash UnleashException)))
 
 (deftype Subscriber [on-error
                      on-event

--- a/src/unleash_client_clojure/unleash.clj
+++ b/src/unleash_client_clojure/unleash.clj
@@ -2,12 +2,12 @@
   (:require [unleash-client-clojure.builder :as builder]
             [unleash-client-clojure.util]
             [unleash_client_clojure.variant])
-  (:import [no.finn.unleash DefaultUnleash EvaluatedToggle]
-           [no.finn.unleash.strategy Strategy]
-           [no.finn.unleash UnleashContext Variant]
-           [no.finn.unleash.variant Payload]
-           [java.util Optional]
-           [unleash_client_clojure.util BiFunctionWrapper]))
+  (:import (io.getunleash DefaultUnleash EvaluatedToggle)
+           (io.getunleash.strategy Strategy)
+           (io.getunleash UnleashContext Variant MoreOperations)
+           (io.getunleash.variant Payload)
+           (java.util Optional)
+           (unleash_client_clojure.util BiFunctionWrapper)))
 
 (defn payload->map [^Payload payload]
   {:type (.getType payload)
@@ -80,15 +80,15 @@
     (.more this))
   (evaluate-all-toggles 
     ([this]
-     (vec (.evaluateAllToggles (more this))))
+     (vec (.evaluateAllToggles ^MoreOperations (more this))))
     ([this context]
-     (vec (.evaluateAllToggles (more this) ^UnleashContext context))))
+     (vec (.evaluateAllToggles ^MoreOperations (more this) ^UnleashContext context))))
   (get-feature-toggle-names [this]
-    (vec (.getFeatureToggleNames (more this))))
+    (vec (.getFeatureToggleNames ^MoreOperations (more this))))
   (register-count [this toggle-name enabled?]
-    (.count (more this) toggle-name enabled?))
+    (.count ^MoreOperations (more this) toggle-name enabled?))
   (count-variant [this toggle-name variant-name]
-    (.countVariant (more this) toggle-name variant-name)))
+    (.countVariant ^MoreOperations (more this) toggle-name variant-name)))
     
 
 (defn build

--- a/src/unleash_client_clojure/util.clj
+++ b/src/unleash_client_clojure/util.clj
@@ -1,5 +1,5 @@
 (ns unleash-client-clojure.util
-  (:import [java.util.function BiFunction]))
+  (:import (java.util.function BiFunction)))
 
 (deftype BiFunctionWrapper [f]
   BiFunction

--- a/src/unleash_client_clojure/variant.clj
+++ b/src/unleash_client_clojure/variant.clj
@@ -1,10 +1,10 @@
 (ns unleash-client-clojure.variant
-  (:import [no.finn.unleash.variant Payload]
-           [no.finn.unleash Variant]
-           [java.util Optional]))
+  (:import (io.getunleash.variant Payload)
+           (io.getunleash Variant)
+           (java.util Optional)))
 
 (defprotocol IVariant
-  "A protocol to bridge the Java class no.finn.unleash.Variant into Clojure.
+  "A protocol to bridge the Java class io.getunleash.Variant into Clojure.
   The class is used in unit tests to change the state of a FakeUnleash instance."
   (variant-enabled? [this] "Returns whether the variant is active or not.")
   (get-name [this] "Returns the variant's name.")

--- a/test/unleash_client_clojure/builder_test.clj
+++ b/test/unleash_client_clojure/builder_test.clj
@@ -4,11 +4,11 @@
             [unleash-client-clojure.context :as c]
             [unleash-client-clojure.subscriber :as subscriber]
             [clojure.string :as s])
-  (:import [java.io File]
-           [no.finn.unleash CustomHttpHeadersProvider UnleashContextProvider]
-           [no.finn.unleash.strategy DefaultStrategy] 
-           [no.finn.unleash.repository ToggleBootstrapProvider]
-           [java.net Proxy]))
+  (:import (java.io File)
+           (io.getunleash CustomHttpHeadersProvider UnleashContextProvider)
+           (io.getunleash.strategy DefaultStrategy)
+           (io.getunleash.repository ToggleBootstrapProvider)
+           (java.net Proxy)))
 
 (deftest builder
   (testing "building unleash sets correct config"

--- a/test/unleash_client_clojure/unleash_test.clj
+++ b/test/unleash_client_clojure/unleash_test.clj
@@ -3,8 +3,8 @@
             [unleash-client-clojure.variant :as v]
             [unleash-client-clojure.fake]
             [clojure.test :refer [testing is deftest]])
-  (:import [no.finn.unleash FakeUnleash Variant]
-           [no.finn.unleash.variant Payload]))
+  (:import [io.getunleash FakeUnleash Variant]
+           [io.getunleash.variant Payload]))
 
 (deftest is-enabled
   (let [fake-unleash (FakeUnleash.)]


### PR DESCRIPTION
We just started exploring feature flags and came across unleash and this library. I started writing my own wrapper and I realized you already have a great one! It seems like their docs have recently been updated to use `io.getunleash/unleash-client-java` instead so I'm sending this PR. Not sure if this warrants a major version bump or not. I tweaked the `:imports` from vectors to lists per https://stuartsierra.com/2016/clojure-how-to-ns.html#vectors-or-lists-1 . If you'd prefer to keep the vector styling let me know and I can change them back. Cheers!